### PR TITLE
chore: 替换示例网址

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -11,7 +11,7 @@ AstroBox通过`manifest.json`来描述并配置插件。一个正常的`manifest
 |version|插件版本|1.0|
 |description|插件简介|这是一个示例插件|
 |author|插件作者|Example Studios|
-|website|插件网页（也可以填github开源仓库）|https://xxx.com|
+|website|插件网页（也可以填github开源仓库）|https://example.com|
 |entry|插件入口js文件|entry.js|
 |api_level|插件API版本|1|
 |permissions|插件运行所需的权限列表|["lifecycle", "event"]|


### PR DESCRIPTION
`xxx.com`是黄色网站，建议替换为example.com